### PR TITLE
Allow setting colors programatically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.novoda:bintray-release:0.8.1'
         // NOTE: Do not place your application dependencies here; they belong

--- a/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
+++ b/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
@@ -112,6 +112,10 @@ class CounterView : AppCompatTextView {
             } finally {
                 styleAttributes.recycle()
             }
+        } ?: run {
+            counterErrorTextColor = ContextCompat.getColor(getContext(), R.color.red)
+            counterTextColor = ContextCompat.getColor(getContext(), R.color.off_black)
+            counterMode = CounterMode.STANDARD
         }
     }
 

--- a/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
+++ b/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
@@ -1,6 +1,7 @@
 package org.buffer.android.counterview
 
 import android.content.Context
+import android.support.annotation.ColorInt
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatTextView
 import android.text.Editable
@@ -40,8 +41,10 @@ class CounterView : AppCompatTextView {
             updateCounterValue(textView?.length() ?: 0)
         }
 
-    private var counterTextColor = -1
-    private var counterErrorTextColor = -1
+    @ColorInt
+    var counterTextColor = -1
+    @ColorInt
+    var counterErrorTextColor = -1
 
     fun attachToEditText(editText: EditText) {
         if (this.textView != null) {

--- a/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
+++ b/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
@@ -32,19 +32,17 @@ class CounterView : AppCompatTextView {
     var charactersRemainingUntilCounterDisplay: Int? = null
         set(value) {
             field = value
-            updateCounterValue(textView?.length() ?: 0)
+            updateCounterValue(textViewContentLength())
         }
 
     var counterMaxLength: Int = 0
         set(value) {
             field = value
-            updateCounterValue(textView?.length() ?: 0)
+            updateCounterValue(textViewContentLength())
         }
 
-    @ColorInt
-    var counterTextColor = -1
-    @ColorInt
-    var counterErrorTextColor = -1
+    private var counterTextColor = -1
+    private var counterErrorTextColor = -1
 
     fun attachToEditText(editText: EditText) {
         if (this.textView != null) {
@@ -85,12 +83,28 @@ class CounterView : AppCompatTextView {
         }
         contentDescription = context.getString(R.string.character_count_description,
                 contentLength, counterMaxLength)
+        updateTextColor(contentLength)
+    }
+
+    fun setCounterTextColor(@ColorInt color: Int) {
+        counterTextColor = color
+        updateTextColor(textViewContentLength())
+    }
+
+    fun setCounterErrorTextColor(@ColorInt color: Int) {
+        counterErrorTextColor = color
+        updateTextColor(textViewContentLength())
+    }
+
+    private fun updateTextColor(contentLength: Int) {
         if (contentLength > counterMaxLength) {
             setTextColor(counterErrorTextColor)
         } else {
             setTextColor(counterTextColor)
         }
     }
+
+    private fun textViewContentLength() = textView?.length() ?: 0
 
     private fun handleAttributes(context: Context, attrs: AttributeSet?) {
         attrs?.let {

--- a/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
+++ b/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
@@ -98,10 +98,10 @@ class CounterView : AppCompatTextView {
             try {
                 counterTextColor = styleAttributes
                         .getColor(R.styleable.CounterView_counterTextColor,
-                                ContextCompat.getColor(getContext(), R.color.red))
+                                ContextCompat.getColor(getContext(), R.color.off_black))
                 counterErrorTextColor = styleAttributes
                         .getColor(R.styleable.CounterView_counterErrorTextColor,
-                                ContextCompat.getColor(getContext(), R.color.off_black))
+                                ContextCompat.getColor(getContext(), R.color.red))
                 val counterMode = styleAttributes
                         .getString(R.styleable.CounterView_counterMode)
                 if (counterMode != null) {


### PR DESCRIPTION
When creating this view programmatically, there was no way to set the colors. The colors were then `-1` and the count not visible.

This also sets the defaults when the view is created programmatically.