### PR TITLE
Add content description

### DIFF
--- a/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
+++ b/lib/src/main/java/org/buffer/android/counterview/CounterView.kt
@@ -69,16 +69,19 @@ class CounterView : AppCompatTextView {
         }
         text = when (counterMode) {
             CounterMode.DESCENDING -> {
-                val remainingcounterMaxLength = counterMaxLength - contentLength
-                remainingcounterMaxLength.toString()
+                val remainingCounterMaxLength = counterMaxLength - contentLength
+                remainingCounterMaxLength.toString()
             }
             CounterMode.ASCENDING -> {
                 contentLength.toString()
             }
             CounterMode.STANDARD -> {
-                contentLength.toString() + "/" + counterMaxLength
+                 context.getString(R.string.character_count_divider,
+                         contentLength, counterMaxLength)
             }
         }
+        contentDescription = context.getString(R.string.character_count_description,
+                contentLength, counterMaxLength)
         if (contentLength > counterMaxLength) {
             setTextColor(counterErrorTextColor)
         } else {

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="character_count_divider">%1$d/%2$d</string>
+    <string name="character_count_description">%1$d of %2$d characters</string>
+</resources>


### PR DESCRIPTION
Now when the count is at say "60/240", TalkBack will say "60 of 240 characters" instead of "60 240ths".